### PR TITLE
Adding support for UIDocumentInteractionController which allows more exp...

### DIFF
--- a/Classes/WDCanvasController.h
+++ b/Classes/WDCanvasController.h
@@ -14,7 +14,6 @@
 #import "WDActionSheet.h"
 #import "WDBar.h"
 #import "WDDocumentReplay.h"
-#import <MessageUI/MFMailComposeViewController.h>
 
 typedef enum {
     WDInterfaceModeHidden, // all adornments are hidden
@@ -42,8 +41,7 @@ typedef enum {
 @class WDUnlockView;
 
 @interface WDCanvasController : UIViewController <UINavigationControllerDelegate, UIImagePickerControllerDelegate,
-                                                    MFMailComposeViewControllerDelegate, UIPopoverControllerDelegate,
-                                                        WDActionSheetDelegate, WDDocumentReplayDelegate, WDActionNameViewDelegate>
+                                                    UIPopoverControllerDelegate, WDActionSheetDelegate, WDDocumentReplayDelegate, WDActionNameViewDelegate, UIDocumentInteractionControllerDelegate>
 {
     WDBarItem           *album_;
     WDBarItem           *undo_;
@@ -64,6 +62,8 @@ typedef enum {
 
     WDHueSaturationController   *hueController_;
     WDColorBalanceController   *balanceController_;
+
+    NSURL *exportFileUrl;
 }
 
 @property (nonatomic) WDDocument *document;
@@ -98,6 +98,7 @@ typedef enum {
 @property (nonatomic) BOOL wasPlayingBeforeRotation;
 
 @property (nonatomic) WDArtStoreController *artStoreController;
+@property (strong, nonatomic) UIDocumentInteractionController *documentInteractionController;
 
 - (void) updateTitle;
 - (void) hidePopovers;


### PR DESCRIPTION
...orting options (Google Drive for example). Based on similar patch for InkPad.

Removes existing email options on action menu and launches UIDocumentInteractionController from there instead.

Quite a conservative patch, trying to minimise disruption. An alternative would be to replace the existing action sheet entirely. Losses would be the Duplicate menu option and the custom message for Twitter and Facebook posts. All other options (Adding to Photos, Copy to Pasteboard, etc) are available through the UIDocumentInteractionController. If you'd prefer that option I'd be happy to change and re-submit.
